### PR TITLE
don’t force line wrapping of prose

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -3,6 +3,7 @@ module.exports = {
   trailingComma: 'none',
   singleQuote: true,
   printWidth: 120,
+  proseWrap: 'never',
   tabWidth: 2,
   useTabs: false,
   jsxSingleQuote: true,


### PR DESCRIPTION
Tables in our docs and blog posts get really gnarly with the auto-formatting Prettier employs since our code editors softwrap text. The only way to stop that autoformatting is to add `<!-- prettier-ignore -->` to _every_ table that might have long text (not sustainable) or to employ `proseWrap: 'never'` in addition to a defined `printLength`. We already have the print length, so let’s make sure our prose never wraps 🙏 

Reference: https://github.com/prettier/prettier/issues/5651 
Example of the nasty markdown table: https://github.com/planetscale/www2/pull/1515#pullrequestreview-1361552097 
