### PR TITLE
Rollback prose line length edit

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -3,7 +3,6 @@ module.exports = {
   trailingComma: 'none',
   singleQuote: true,
   printWidth: 120,
-  proseWrap: 'never',
   tabWidth: 2,
   useTabs: false,
   jsxSingleQuote: true,


### PR DESCRIPTION
Reverts planetscale/core-prettier#1

While this has been helpful for markdown tables, its effects are too far reaching for other prose-related text that should have line breaks preserved. Rolling back!